### PR TITLE
[refactor] #69 메인 색상 관리

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -4,13 +4,15 @@ import GlobalStyle from './GlobalStyle';
 import Main from './pages/Main';
 import Apply from './pages/Apply';
 
+const todayColor = 'blue';
+
 export default function App() {
   return (
     <>
       <Global styles={GlobalStyle} />
       <Routes>
-        <Route path="/" element={<Main />} />
-        <Route path="/Apply" element={<Apply />} />
+        <Route path="/" element={<Main color={todayColor} />} />
+        <Route path="/Apply" element={<Apply color={todayColor} />} />
       </Routes>
     </>
   );

--- a/src/pages/Apply.jsx
+++ b/src/pages/Apply.jsx
@@ -3,9 +3,7 @@ import Nav from '../component/Nav';
 import Forms from '../component/Forms';
 import LoginButton from '../component/LoginButton';
 
-const todayColor = 'green';
-
-export default function Apply() {
+export default function Apply({ color }) {
   alert('지원 기간이 아닙니다.');
   window.location.href = '/';
 
@@ -13,8 +11,8 @@ export default function Apply() {
 
   return (
     <>
-      <Nav color={todayColor} />
-      {name ? <Forms color={todayColor} email={email} /> : <LoginButton />}
+      <Nav color={color} />
+      {name ? <Forms color={color} email={email} /> : <LoginButton />}
     </>
   );
 }

--- a/src/pages/Main.jsx
+++ b/src/pages/Main.jsx
@@ -2,8 +2,6 @@ import MainContainer from '../component/MainContainer';
 import MobileContainer from '../component/Mobile/MobileContanier';
 import { isMobile } from '../utils/deviceChecker';
 
-const todayColor = 'green';
-
-export default function Main() {
-  return isMobile() ? <MobileContainer color={todayColor} /> : <MainContainer color={todayColor} />;
+export default function Main({ color }) {
+  return isMobile() ? <MobileContainer color={color} /> : <MainContainer color={color} />;
 }


### PR DESCRIPTION
## 1. 무슨 이유로 코드를 변경했나요?
- #68 에 적혀있는 이슈를 해결하였습니다.
- 2개로 나눠져있는 메인 색상 관리를 1곳에서 진행하도록 리팩토링하였습니다.

## 2. 어떤 위험이나 장애를 발견했나요?
- 처음에는 `redux-toolkit`을 사용하려고 했습니다.
- 하지만 굳이 `redux-toolkit`을 사용할 필요가 없다고 판단하였습니다.
- 왜냐하면 메인 색상은 `dispatch`를 활용하여 바뀌는 것이 없기 때문입니다.
- 따라서 `props`를 전달하는 방식으로 사용하였습니다.

## 3. 완료 사항

- 모든 구현 사항을 완료하였습니다.
- 현재는 유저가 색상을 변경하도록 할 계획이 없지만, 추후에 기능을 추가한다면 상태 관리 라이브러리를 사용할 예정입니다.